### PR TITLE
Add an easier way to work with the guessed OS

### DIFF
--- a/FingerprintUSBHost.cpp
+++ b/FingerprintUSBHost.cpp
@@ -29,17 +29,34 @@ int FingerprintUSBHost_::getDescriptor(USBSetup& setup) {
     return 0;
 }
 
-void FingerprintUSBHost_::guessHostOS(String &os) {
+GuessedHost::OSVariant FingerprintUSBHost_::guessHostOS(void) {
 
     if (not_mac > 0 && not_linux > 0 && maybe_win > 0) {
-        os="Windows";
+        return GuessedHost::WINDOWS;
     } else if ( maybe_linux > 0 && not_linux == 0 ) {
-        os="Linux";
+        return GuessedHost::LINUX;
     } else if ( not_mac == 0)  {
-        os="MacOS";
+        return GuessedHost::MACOS;
 
     } else {
+        return GuessedHost::UNSURE;
+    }
+}
+
+void FingerprintUSBHost_::guessHostOS(String &os) {
+    switch (guessHostOS ()) {
+    case GuessedHost::WINDOWS:
+        os="Windows";
+        break;
+    case GuessedHost::LINUX:
+        os="Linux";
+        break;
+    case GuessedHost::MACOS:
+        os="MacOS";
+        break;
+    default:
         os="unsure";
+        break;
     }
 }
 

--- a/FingerprintUSBHost.h
+++ b/FingerprintUSBHost.h
@@ -4,11 +4,20 @@
 #include <Arduino.h>
 #include "PluggableUSB.h"
 
+namespace GuessedHost {
+typedef enum {
+    UNSURE,
+    LINUX,
+    WINDOWS,
+    MACOS,
+} OSVariant;
+};
 
 class FingerprintUSBHost_ : public PluggableUSBModule {
   public:
     FingerprintUSBHost_(void);
     int begin(void);
+    GuessedHost::OSVariant guessHostOS(void);
     void guessHostOS(String &os);
     USBSetup usbSetups[32];
     int usbSetupCount = 0;


### PR DESCRIPTION
Instead of storing the OS in a string, have a variant of `guessHostOS` that returns an enum. That makes it easier for users of the library to work with the results.
