### PR TITLE
Don't use full 8bit ints for bools

### DIFF
--- a/FingerprintUSBHost.cpp
+++ b/FingerprintUSBHost.cpp
@@ -18,12 +18,11 @@ int FingerprintUSBHost_::getDescriptor(USBSetup& setup) {
 
 
     if (setup.wLength == 0xff) {
-        maybe_linux++;
-        maybe_win++;
-        not_mac++; // In testing, MacOS NEVER sets a descript request lenght of 255
+        guess.maybe_linux = 1;
+        guess.maybe_win = 1;
+        guess.not_mac = 1; // In testing, MacOS NEVER sets a descript request lenght of 255
     } else {
-
-        not_linux++; // In testing, Linux ALWAYS sets a descriptor request length of 255;
+        guess.not_linux = 1; // In testing, Linux ALWAYS sets a descriptor request length of 255;
     }
 
     return 0;
@@ -31,11 +30,11 @@ int FingerprintUSBHost_::getDescriptor(USBSetup& setup) {
 
 GuessedHost::OSVariant FingerprintUSBHost_::guessHostOS(void) {
 
-    if (not_mac > 0 && not_linux > 0 && maybe_win > 0) {
+    if (guess.not_mac && guess.not_linux && guess.maybe_win) {
         return GuessedHost::WINDOWS;
-    } else if ( maybe_linux > 0 && not_linux == 0 ) {
+    } else if ( guess.maybe_linux && !guess.not_linux ) {
         return GuessedHost::LINUX;
-    } else if ( not_mac == 0)  {
+    } else if ( ! guess.not_mac )  {
         return GuessedHost::MACOS;
 
     } else {
@@ -67,6 +66,7 @@ bool FingerprintUSBHost_::setup(USBSetup& setup) {
 }
 
 FingerprintUSBHost_::FingerprintUSBHost_(void) : PluggableUSBModule(0, 0, epType) {
+    memset(&guess, 0, sizeof(guess));
     PluggableUSB().plug(this);
 }
 

--- a/FingerprintUSBHost.h
+++ b/FingerprintUSBHost.h
@@ -31,13 +31,14 @@ class FingerprintUSBHost_ : public PluggableUSBModule {
 
   private:
     uint8_t epType[0];
-    uint8_t maybe_linux = 0;
-    uint8_t maybe_win = 0;
-    uint8_t maybe_mac = 0;
-    uint8_t not_linux = 0;
-    uint8_t not_win = 0;
-    uint8_t not_mac = 0;
-
+    struct {
+        uint8_t maybe_linux:1;
+        uint8_t maybe_win:1;
+        uint8_t maybe_mac:1;
+        uint8_t not_linux:1;
+        uint8_t not_win:1;
+        uint8_t not_mac:1;
+    } guess;
 
 
 };


### PR DESCRIPTION
Instead of using a `uint8_t` for all `maybe_` and `not_` variables, make them one-bit instead, as we only ever check for >0. This saves about five bytes of data, and some code too, while maintaining the same functionality.
