### PR TITLE
Remove seemingly-unused giant array of USBSetup structs

### DIFF
--- a/examples/DumpFingerprint/DumpFingerprint.ino
+++ b/examples/DumpFingerprint/DumpFingerprint.ino
@@ -1,3 +1,4 @@
+#define DEBUG
 #include "FingerprintUSBHost.h"
 #include "Keyboard.h"
 

--- a/src/FingerprintUSBHost.cpp
+++ b/src/FingerprintUSBHost.cpp
@@ -9,8 +9,6 @@ int FingerprintUSBHost_::getInterface(uint8_t* interfaceCount) {
 }
 
 int FingerprintUSBHost_::getDescriptor(USBSetup& setup) {
-    usbSetups[usbSetupCount++] = setup;
-
     if (setup.bmRequestType != REQUEST_DEVICETOHOST  || setup.bRequest != GET_DESCRIPTOR || setup.wValueH != USB_STRING_DESCRIPTOR_TYPE)  {
 
         return 0;
@@ -61,7 +59,6 @@ void FingerprintUSBHost_::guessHostOS(String &os) {
 
 
 bool FingerprintUSBHost_::setup(USBSetup& setup) {
-//    usbSetups[usbSetupCount++] = setup;
     return false;
 }
 

--- a/src/FingerprintUSBHost.cpp
+++ b/src/FingerprintUSBHost.cpp
@@ -9,6 +9,10 @@ int FingerprintUSBHost_::getInterface(uint8_t* interfaceCount) {
 }
 
 int FingerprintUSBHost_::getDescriptor(USBSetup& setup) {
+#ifdef DEBUG
+    usbSetups[usbSetupCount++] = setup;
+#endif
+
     if (setup.bmRequestType != REQUEST_DEVICETOHOST  || setup.bRequest != GET_DESCRIPTOR || setup.wValueH != USB_STRING_DESCRIPTOR_TYPE)  {
 
         return 0;

--- a/src/FingerprintUSBHost.h
+++ b/src/FingerprintUSBHost.h
@@ -19,7 +19,6 @@ class FingerprintUSBHost_ : public PluggableUSBModule {
     int begin(void);
     GuessedHost::OSVariant guessHostOS(void);
     void guessHostOS(String &os);
-    int usbSetupCount = 0;
 
   protected:
     // Implementation of the PluggableUSBModule

--- a/src/FingerprintUSBHost.h
+++ b/src/FingerprintUSBHost.h
@@ -19,6 +19,10 @@ class FingerprintUSBHost_ : public PluggableUSBModule {
     int begin(void);
     GuessedHost::OSVariant guessHostOS(void);
     void guessHostOS(String &os);
+#ifdef DEBUG
+    USBSetup usbSetups[32];
+    int usbSetupCount = 0;
+#endif
 
   protected:
     // Implementation of the PluggableUSBModule

--- a/src/FingerprintUSBHost.h
+++ b/src/FingerprintUSBHost.h
@@ -19,7 +19,6 @@ class FingerprintUSBHost_ : public PluggableUSBModule {
     int begin(void);
     GuessedHost::OSVariant guessHostOS(void);
     void guessHostOS(String &os);
-    USBSetup usbSetups[32];
     int usbSetupCount = 0;
 
   protected:


### PR DESCRIPTION
Having HostOS detection enable in Kaleidoscope firmware causes a 256 byte (10%) increase in SRAM usage; by removing this array, the usage only increases by 25 bytes.

I don't have access to a device to test this on, although as far as I can tell, the only place where the usbSetups array is used is in one of the examples in this repo.